### PR TITLE
fix minor style issue which prevents proper search engine indexing

### DIFF
--- a/developers.html
+++ b/developers.html
@@ -13,7 +13,7 @@
 <div id="ens_header_row">
   <div id="ens_header_cell_logo_img"><a href="http://ensmallen.org"><img id="ens_logo_img" src="ensmallen_logo.png" alt="ensmallen" align="top" border="0"></a></div>
   <div id="ens_header_spacer"></div>
-  <div id="ens_header_cell_logo_txt"><big><big><b>en</b>small<b>en</b></big><br>flexible C++ library for efficient mathematical optimization</big></div>
+  <div id="ens_header_cell_logo_txt"><big><big><b>ensmallen</b></big><br>flexible C++ library for efficient mathematical optimization</big></div>
 </div>
 </div>
 

--- a/docs.html
+++ b/docs.html
@@ -13,7 +13,7 @@
 <div id="ens_header_row">
   <div id="ens_header_cell_logo_img"><a href="http://ensmallen.org"><img id="ens_logo_img" src="ensmallen_logo.png" alt="ensmallen" align="top" border="0"></a></div>
   <div id="ens_header_spacer"></div>
-  <div id="ens_header_cell_logo_txt"><big><big><b>en</b>small<b>en</b></big><br>flexible C++ library for efficient mathematical optimization</big></div>
+  <div id="ens_header_cell_logo_txt"><big><big><b>ensmallen</b></big><br>flexible C++ library for efficient mathematical optimization</big></div>
 </div>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <div id="ens_header_row">
   <div id="ens_header_cell_logo_img"><a href="http://ensmallen.org"><img id="ens_logo_img" src="ensmallen_logo.png" alt="ensmallen" align="top" border="0"></a></div>
   <div id="ens_header_spacer"></div>
-  <div id="ens_header_cell_logo_txt"><big><big><b>en</b>small<b>en</b></big><br>flexible C++ library for efficient mathematical optimization</big></div>
+  <div id="ens_header_cell_logo_txt"><big><big><b>ensmallen</b></big><br>flexible C++ library for efficient mathematical optimization</big></div>
 </div>
 </div>
 

--- a/questions.html
+++ b/questions.html
@@ -13,7 +13,7 @@
 <div id="ens_header_row">
   <div id="ens_header_cell_logo_img"><a href="http://ensmallen.org"><img id="ens_logo_img" src="ensmallen_logo.png" alt="ensmallen" align="top" border="0"></a></div>
   <div id="ens_header_spacer"></div>
-  <div id="ens_header_cell_logo_txt"><big><big><b>en</b>small<b>en</b></big><br>flexible C++ library for efficient mathematical optimization</big></div>
+  <div id="ens_header_cell_logo_txt"><big><big><b>ensmallen</b></big><br>flexible C++ library for efficient mathematical optimization</big></div>
 </div>
 </div>
 


### PR DESCRIPTION
Turns out that using styling with part of the 'ensmallen' word put into boldface (ie. **en**small**en**) actually causes some search engines to incorrectly index the pages. Instead of seeing 'ensmallen', they see 'en&nbsp;small&nbsp;en'. This PR simply puts all of the 'ensmallen' word into boldface at the masthead in each page.

