### PR TITLE
bump minimum Armadillo version

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,8 +11,8 @@ order: 1
 
 **requirements**
 
- * recent C++ compiler with C++11 support
- * [Armadillo](http://arma.sourceforge.net) (>= 9.800)
+ * recent C++ compiler with C++14 support
+ * [Armadillo](https://arma.sourceforge.net) (>= 10.8)
  * OpenBLAS or Intel MKL or LAPACK (see Armadillo site for details)
 
 **license**


### PR DESCRIPTION
Update ensmallen webpage to state we now need Armadillo 10.8 and C++14.

Companion to https://github.com/mlpack/ensmallen/pull/400 and https://github.com/mlpack/ensmallen/pull/404
